### PR TITLE
Add issue tracking

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -4,7 +4,7 @@
 /// This function does something really risky!
 ///
 /// Don't use it yet!
-#[stability::unstable(feature = "risky-function")]
+#[stability::unstable(feature = "risky-function", issue = "#101")]
 pub fn risky_function() {
     unimplemented!()
 }


### PR DESCRIPTION
This PR adds the `issue` field in the `unstable` attribute.
This way, an unstable feature can be actively tracked by the user.

Very minor addition

#### Usage

```
/// This function does something really risky!
///
/// Don't use it yet!
#[stability::unstable(feature = "risky-function", issue = "#101")]
pub fn risky_function() {
    unimplemented!()
}
```

This will output:

---

This function does something really risky!

Don’t use it yet!

#### Availability
**This API is marked as unstable** and is only available when the unstable-risky-function crate feature is enabled. This comes with no stability guarantees, and could be changed or removed at any time.

The tracking issue is: `#101`

