### PR TITLE
refactor: migrate to syn 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 quote = "1"
 
 [dependencies.syn]
-version = "1"
+version = "2"
 features = ["derive", "full"]
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,19 +98,20 @@ mod unstable;
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn unstable(args: TokenStream, item: TokenStream) -> TokenStream {
-    let args = parse_macro_input!(args as syn::AttributeArgs);
-    let attr = unstable::UnstableAttribute::from(args);
+pub fn unstable(args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut attributes = unstable::UnstableAttribute::default();
+    let attributes_parser = syn::meta::parser(|meta| attributes.parse(meta));
+    parse_macro_input!(args with attributes_parser);
 
-    match parse_macro_input!(item as Item) {
-        Item::Type(item_type) => attr.expand(item_type),
-        Item::Enum(item_enum) => attr.expand(item_enum),
-        Item::Struct(item_struct) => attr.expand(item_struct),
-        Item::Fn(item_fn) => attr.expand(item_fn),
-        Item::Mod(item_mod) => attr.expand(item_mod),
-        Item::Trait(item_trait) => attr.expand(item_trait),
-        Item::Const(item_const) => attr.expand(item_const),
-        Item::Static(item_static) => attr.expand(item_static),
+    match parse_macro_input!(input as Item) {
+        Item::Type(item_type) => attributes.expand(item_type),
+        Item::Enum(item_enum) => attributes.expand(item_enum),
+        Item::Struct(item_struct) => attributes.expand(item_struct),
+        Item::Fn(item_fn) => attributes.expand(item_fn),
+        Item::Mod(item_mod) => attributes.expand(item_mod),
+        Item::Trait(item_trait) => attributes.expand(item_trait),
+        Item::Const(item_const) => attributes.expand(item_const),
+        Item::Static(item_static) => attributes.expand(item_static),
         _ => panic!("unsupported item type"),
     }
 }

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -1,14 +1,31 @@
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
+use syn::meta::ParseNestedMeta;
+use syn::parse::Result;
 use syn::{parse_quote, Visibility};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct UnstableAttribute {
     feature: Option<String>,
-	issue: Option<String>
+    issue: Option<String>,
 }
 
 impl UnstableAttribute {
+    pub(crate) fn parse(&mut self, meta: ParseNestedMeta) -> Result<()> {
+        if meta.path.is_ident("feature") {
+            match meta.value()?.parse()? {
+                syn::Lit::Str(s) => self.feature = Some(s.value()),
+                _ => panic!(),
+            }
+        } else if meta.path.is_ident("issue") {
+            match meta.value()?.parse()? {
+                syn::Lit::Str(s) => self.issue = Some(s.value()),
+                _ => panic!(),
+            }
+        }
+        Ok(())
+    }
+
     fn crate_feature_name(&self) -> String {
         if let Some(name) = self.feature.as_deref() {
             format!("unstable-{}", name)
@@ -22,9 +39,9 @@ impl UnstableAttribute {
         if item.is_public() {
             let feature_name = self.crate_feature_name();
 
-			if let Some(issue) = &self.issue {
-				let doc_addendum = format!(
-					"\n\
+            if let Some(issue) = &self.issue {
+                let doc_addendum = format!(
+                    "\n\
 					# Availability\n\
 					\n\
 					**This API is marked as unstable** and is only available when \
@@ -33,27 +50,26 @@ impl UnstableAttribute {
 
 The tracking issue is: `{}`
 				",
-					feature_name,
-					issue
-				);
-				item.push_attr(parse_quote! {
-					#[doc = #doc_addendum]
-				});
-			} else {
-				let doc_addendum = format!(
-					"\n\
+                    feature_name, issue
+                );
+                item.push_attr(parse_quote! {
+                    #[doc = #doc_addendum]
+                });
+            } else {
+                let doc_addendum = format!(
+                    "\n\
 					# Availability\n\
 					\n\
 					**This API is marked as unstable** and is only available when \
 					the `{}` crate feature is enabled. This comes with no stability \
 					guarantees, and could be changed or removed at any time.\
 				",
-					feature_name
-				);
-				item.push_attr(parse_quote! {
-					#[doc = #doc_addendum]
-				});
-			}
+                    feature_name
+                );
+                item.push_attr(parse_quote! {
+                    #[doc = #doc_addendum]
+                });
+            }
 
             let mut hidden_item = item.clone();
             *hidden_item.visibility_mut() = parse_quote! {
@@ -71,34 +87,6 @@ The tracking issue is: `{}`
         } else {
             item.into_token_stream().into()
         }
-    }
-}
-
-impl From<syn::AttributeArgs> for UnstableAttribute {
-    fn from(args: syn::AttributeArgs) -> Self {
-        let mut feature = None;
-		let mut issue = None;
-
-        for arg in args {
-            match arg {
-                syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => {
-                    if name_value.path.is_ident("feature") {
-                        match name_value.lit {
-                            syn::Lit::Str(s) => feature = Some(s.value()),
-                            _ => panic!(),
-                        }
-                    } else if name_value.path.is_ident("issue") {
-						match name_value.lit {
-							syn::Lit::Str(s) => issue = Some(s.value()),
-							_ => panic!()
-						}
-					}
-                }
-                _ => {}
-            }
-        }
-
-        Self { feature, issue }
     }
 }
 


### PR DESCRIPTION
This PR updates the codebase to use the latest version of the `syn` crate.

See https://github.com/ratatui-org/ratatui/issues/961
