### PR TITLE
feat: allow use statements to be marked unstable

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -18,3 +18,17 @@ pub fn risky_function() {
 pub struct RiskyStruct {
     pub x: u8,
 }
+
+mod private {
+    /// This function does something really risky!
+    ///
+    /// Don't use it yet!
+    #[stability::unstable(feature = "risky-private-function")]
+    pub fn risky_private_function() {
+        unimplemented!()
+    }
+}
+
+#[allow(unused_imports)]
+#[stability::unstable(feature = "risky-private-function")]
+pub use private::risky_private_function;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ pub fn unstable(args: TokenStream, input: TokenStream) -> TokenStream {
         Item::Trait(item_trait) => attributes.expand(item_trait),
         Item::Const(item_const) => attributes.expand(item_const),
         Item::Static(item_static) => attributes.expand(item_static),
+        Item::Use(item_use) => attributes.expand(item_use),
         _ => panic!("unsupported item type"),
     }
 }

--- a/src/unstable.rs
+++ b/src/unstable.rs
@@ -136,6 +136,7 @@ impl_has_visibility!(
     syn::ItemTrait,
     syn::ItemConst,
     syn::ItemStatic,
+    syn::ItemUse,
 );
 
 impl ItemLike for syn::ItemStruct {


### PR DESCRIPTION
This allows the pattern of re-exporting code defined in private modules,
while still requiring the unstable feature to be enabled.
